### PR TITLE
Support ordering templates

### DIFF
--- a/js/tinymce-templates.js
+++ b/js/tinymce-templates.js
@@ -97,7 +97,7 @@ var tinymceTemplates;
 			}).done(function(data){
 				$.each(data, function(key, tpl){
 					var option = $('<option />');
-					$(option).attr('value', key);
+					$(option).attr('value', tpl.id);
 					$(option).text(tpl.title);
 					$('#tinymce-templates-list').append(option);
 				});

--- a/tests/test-tinymce-templates.php
+++ b/tests/test-tinymce-templates.php
@@ -18,7 +18,15 @@ class TinyMCE_Templates_Test extends WP_UnitTestCase
 		) );
 		$templates = $tinymce_templates->get_templates();
 
-		$this->assertTrue( isset( $templates[ $post_id ] ) );
+		// Find a template with the ID
+		$found = false;
+		foreach ( $templates as $tpl ) {
+			if ( isset( $tpl['id'] ) && intval( $tpl['id'] ) == $post_id ) {
+				$found = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found );
 
 		$_GET['template_id'] = $post_id;
 		$templates = $tinymce_templates->get_templates();

--- a/tinymce-templates.php
+++ b/tinymce-templates.php
@@ -375,6 +375,7 @@ class TinyMCE_Templates
 				'editor',
 				'revisions',
 				'author',
+				'page-attributes',
 			)
 		);
 		register_post_type( $this->post_type, $args );
@@ -576,8 +577,7 @@ class TinyMCE_Templates
 		$p = array(
 			'post_status' => 'publish',
 			'post_type'   => $this->post_type,
-			'orderby'     => 'date',
-			'order'       => 'DESC',
+			'orderby'     => array( 'menu_order' => 'ASC', 'date' => 'DESC' ),
 			'numberposts' => -1,
 		);
 
@@ -589,7 +589,8 @@ class TinyMCE_Templates
 			$ID = intval( $p->ID );
 			$name = esc_html( apply_filters( 'tinymce_template_title', $p->post_title ) );
 			$desc = esc_html( apply_filters( 'tinymce_template_excerpt', $p->post_excerpt ) );
-			$templates[ $ID ] = array(
+			$templates[] = array(
+				'id'           => $ID,
 				'title'        => $name,
 				'is_shortcode' => get_post_meta( $ID, 'insert_as_shortcode', true ),
 				'content'      => $p->post_content,
@@ -599,8 +600,15 @@ class TinyMCE_Templates
 		$templates = apply_filters( 'tinymce_templates_post_objects', $templates );
 
 		if ( isset( $_GET['template_id'] ) && $_GET['template_id'] ) {
-			if ( isset( $templates[ $_GET['template_id'] ] ) && $templates[ $_GET['template_id'] ] ) {
-				$p = $templates[ $_GET['template_id'] ];
+
+			// Find a template with the ID
+			$p = array();
+			foreach ( $templates as $tpl ) {
+				if ( intval( $tpl['id'] ) != intval( $_GET['template_id'] ) ) continue;
+				$p = $tpl;
+			}
+
+			if ( $p ) {
 				$content = apply_filters(
 					'tinymce_templates',
 					$p['content'],

--- a/tinymce-templates.php
+++ b/tinymce-templates.php
@@ -604,8 +604,10 @@ class TinyMCE_Templates
 			// Find a template with the ID
 			$p = array();
 			foreach ( $templates as $tpl ) {
-				if ( intval( $tpl['id'] ) != intval( $_GET['template_id'] ) ) continue;
-				$p = $tpl;
+				if ( intval( $tpl['id'] ) == intval( $_GET['template_id'] ) ) {
+					$p = $tpl;
+					break;
+				}
 			}
 
 			if ( $p ) {


### PR DESCRIPTION
エディターにて挿入テンプレートを選ぶ際の、テンプレートの並び順を変更できるようにしてみました。
並び順はページ属性: **順序** ( = `menu_order`) の昇順になります。
欲しかったので作ってみました。