### PR TITLE
Add filter to get_templates function to make  wpautop disabling possible.

### DIFF
--- a/tinymce-templates.php
+++ b/tinymce-templates.php
@@ -32,9 +32,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-$tinymce_templates_conf = array(
-	'use_wpautop' => true,
-);
 $tinymce_templates = new TinyMCE_Templates();
 $tinymce_templates->register();
 
@@ -587,6 +584,9 @@ class TinyMCE_Templates
 	public function get_templates()
 	{
 		global $tinymce_templates_conf;
+		if( !isset( $tinymce_templates_conf['use_wpautop'] )){
+			$tinymce_templates_conf['use_wpautop'] = true;
+		}
 		$p = array(
 			'post_status' => 'publish',
 			'post_type'   => $this->post_type,
@@ -624,11 +624,9 @@ class TinyMCE_Templates
 					'tinymce_templates_preview',
 					$p['content']
 				);
-
-				if($tinymce_templates_conf['use_wpautop'] == true){
+				if( $tinymce_templates_conf['use_wpautop'] === true ){
 					$content = wpautop( $content );
 				}
-
 				return array(
 					'content'      => $content,
 					'preview'      => $preview,

--- a/tinymce-templates.php
+++ b/tinymce-templates.php
@@ -32,6 +32,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+$tinymce_templates_conf = array(
+	'use_wpautop' => true,
+);
 $tinymce_templates = new TinyMCE_Templates();
 $tinymce_templates->register();
 
@@ -583,6 +586,7 @@ class TinyMCE_Templates
 
 	public function get_templates()
 	{
+		global $tinymce_templates_conf;
 		$p = array(
 			'post_status' => 'publish',
 			'post_type'   => $this->post_type,
@@ -620,8 +624,13 @@ class TinyMCE_Templates
 					'tinymce_templates_preview',
 					$p['content']
 				);
+
+				if($tinymce_templates_conf['use_wpautop'] == true){
+					$content = wpautop( $content );
+				}
+
 				return array(
-					'content'      => wpautop( $content ),
+					'content'      => $content,
 					'preview'      => $preview,
 					'is_shortcode' => $p['is_shortcode'],
 				);

--- a/tinymce-templates.php
+++ b/tinymce-templates.php
@@ -583,10 +583,6 @@ class TinyMCE_Templates
 
 	public function get_templates()
 	{
-		global $tinymce_templates_conf;
-		if( !isset( $tinymce_templates_conf['use_wpautop'] )){
-			$tinymce_templates_conf['use_wpautop'] = true;
-		}
 		$p = array(
 			'post_status' => 'publish',
 			'post_type'   => $this->post_type,
@@ -624,7 +620,7 @@ class TinyMCE_Templates
 					'tinymce_templates_preview',
 					$p['content']
 				);
-				if( $tinymce_templates_conf['use_wpautop'] === true ){
+				if( apply_filters( 'tinymce_templates_is_wpautop_disabled', false ) === false ){
 					$content = wpautop( $content );
 				}
 				return array(


### PR DESCRIPTION
Hi thank you for great plugin.

I am facing issue with tinymce-templates plugin now.
Issue is *When naked html commented part is on template, unexpected p tags are added before/after comment tag*.
e.g
_\<!-- infomation --\>_ 
will be
_\<p\>\<!-- information --\>\<\/p\>_

So I would like to add filter to get_templates function to make wpautop disabling possible.

Please consider. 
thank you